### PR TITLE
Support Python 2 and 3 tests in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
  - bash miniconda.sh -b -p $HOME/miniconda
  - export PATH="$HOME/miniconda/bin:$PATH"
  - hash -r
- - conda confg --set always_yes yes --set changeps1 no
+ - conda config --set always_yes yes --set changeps1 no
  - conda update -q conda
  - conda info -a
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,26 @@
 language: python
 python:
+ - '2.7'
 # - '3.3'
  - '3.5'
  - '3.6'
 # Not actually using Travis Python...
 
-before_install:
- - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
- - chmod +x miniconda.sh
- - ./miniconda.sh -b
- - export PATH=/home/travis/miniconda3/bin:$PATH
- - conda update --yes conda
-
 install:
- - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy pandas xlrd
+ - sudo apt-get update
+ - if [[ $TRAVIS_PYTHON_VERSION == "2.7" ]]; then
+     wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+   else
+     wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+   fi
+ - bash miniconda.sh -b -p $HOME/miniconda
+ - export PATH="$HOME/miniconda/bin:$PATH"
+ - hash -r
+ - conda confg --set always_yes yes --set changeps1 no
+ - conda update -q conda
+ - conda info -a
 
+ - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy pandas xlrd
+ - source activate test-environment
 script:
- - python3 -m unittest test.test_parsers 
+ - python -m unittest test.test_parsers 


### PR DESCRIPTION
Test under python 2 and python 3 version(s) under Travis CI. Uses conda envirionments to install dependencies.